### PR TITLE
Fix code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/src/plugins/medical_term.py
+++ b/src/plugins/medical_term.py
@@ -22,8 +22,8 @@ class MedicalTermPlugin(BasePlugin):
                         'category': term['category'],
                         'description': term.get('description', '')
                     })
-            except Exception as e:
-                print(f'Error processing term {term["pattern"]}: {str(e)}')
+            except Exception:
+                print('Error processing a medical term.')
                 continue
                 
         return {'terms': found_terms}


### PR DESCRIPTION
Fixes [https://github.com/TemurTurayev/advanced-medical-pdf-converter/security/code-scanning/1](https://github.com/TemurTurayev/advanced-medical-pdf-converter/security/code-scanning/1)

To fix the problem, we should avoid logging sensitive information directly. Instead of logging the specific term pattern and the exception message, we can log a generic error message that does not include sensitive details. This way, we can still be informed about errors without exposing sensitive data.

- Replace the line that logs the error message with a more generic message.
- Ensure that the new log message does not include any sensitive information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
